### PR TITLE
bootstrap activitystreams2 module

### DIFF
--- a/streams-schemas/pom.xml
+++ b/streams-schemas/pom.xml
@@ -34,6 +34,7 @@
 
     <modules>
         <module>streams-schema-activitystreams</module>
+        <module>streams-schema-activitystreams2</module>
     </modules>
 
 </project>

--- a/streams-schemas/streams-schema-activitystreams2/pom.xml
+++ b/streams-schemas/streams-schema-activitystreams2/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.streams</groupId>
+        <artifactId>streams-schemas</artifactId>
+        <version>0.4-incubating-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>streams-schema-activitystreams2</artifactId>
+    <name>${project.artifactId}</name>
+
+    <description>Activity Streams 2.0 schemas</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+    <build>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-it-data</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/w3c/activitystreams/archive/master.zip</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}/test-classes/w3c</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*.json</include>
+                        <include>**/*.jsonld</include>
+                        <include>**/*.owl</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/streams-schemas/streams-schema-activitystreams2/src/test/java/org/w3c/activitystreams/test/ExamplesSerDeIT.java
+++ b/streams-schemas/streams-schema-activitystreams2/src/test/java/org/w3c/activitystreams/test/ExamplesSerDeIT.java
@@ -1,0 +1,116 @@
+package org.w3c.activitystreams.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.io.Charsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class ExamplesSerDeIT {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(ExamplesSerDeIT.class);
+
+    private final static ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Tests that activities matching core-ex* can be parsed by apache streams
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCoreSerDe() throws Exception {
+
+        InputStream testActivityFolderStream = ExamplesSerDeIT.class.getClassLoader()
+                .getResourceAsStream("w3c/activitystreams-master/test");
+        List<String> files = IOUtils.readLines(testActivityFolderStream, Charsets.UTF_8);
+
+        for (String file : files) {
+            if( !file.startsWith(".") && file.contains("core-ex") ) {
+                LOGGER.info("File: activitystreams-master/test/" + file);
+                String testFileString = new String(Files.readAllBytes(Paths.get("target/test-classes/w3c/activitystreams-master/test/" + file)));
+                LOGGER.info("Content: " + testFileString);
+                ObjectNode testFileObjectNode = MAPPER.readValue(testFileString, ObjectNode.class);
+                LOGGER.info("Object:" + testFileObjectNode);
+            }
+        }
+    }
+
+    /**
+     * Tests that activities matching simple* can be parsed by apache streams
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSimpleSerDe() throws Exception {
+
+        InputStream testActivityFolderStream = ExamplesSerDeIT.class.getClassLoader()
+                .getResourceAsStream("w3c/activitystreams-master/test");
+        List<String> files = IOUtils.readLines(testActivityFolderStream, Charsets.UTF_8);
+
+        for (String file : files) {
+            if( !file.startsWith(".") && file.contains("simple") ) {
+                LOGGER.info("File: activitystreams-master/test/" + file);
+                String testFileString = new String(Files.readAllBytes(Paths.get("target/test-classes/w3c/activitystreams-master/test/" + file)));
+                LOGGER.info("Content: " + testFileString);
+                ObjectNode testFileObjectNode = MAPPER.readValue(testFileString, ObjectNode.class);
+                LOGGER.info("Object:" + testFileObjectNode);
+            }
+        }
+    }
+
+    /**
+     * Tests that activities matching vocabulary-ex* can be parsed by apache streams
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testVocabularySerDe() throws Exception {
+
+        InputStream testActivityFolderStream = ExamplesSerDeIT.class.getClassLoader()
+                .getResourceAsStream("w3c/activitystreams-master/test");
+        List<String> files = IOUtils.readLines(testActivityFolderStream, Charsets.UTF_8);
+
+        for (String file : files) {
+            if( !file.startsWith(".") && file.contains("vocabulary-ex") ) {
+                LOGGER.info("File: activitystreams-master/test/" + file);
+                String testFileString = new String(Files.readAllBytes(Paths.get("target/test-classes/w3c/activitystreams-master/test/" + file)));
+                LOGGER.info("Content: " + testFileString);
+                ObjectNode testFileObjectNode = MAPPER.readValue(testFileString, ObjectNode.class);
+                LOGGER.info("Object:" + testFileObjectNode);
+            }
+        }
+    }
+
+    /**
+     * Tests that activities expect to fail cannot be parsed by apache streams
+     *
+     * @throws Exception
+     */
+    @Ignore
+    @Test
+    public void testFailSerDe() throws Exception {
+
+        InputStream testActivityFolderStream = ExamplesSerDeIT.class.getClassLoader()
+                .getResourceAsStream("w3c/activitystreams-master/test/fail");
+        List<String> files = IOUtils.readLines(testActivityFolderStream, Charsets.UTF_8);
+
+        for (String file : files) {
+            if( !file.startsWith(".") && file.contains("vocabulary-ex") ) {
+                LOGGER.info("File: activitystreams-master/test/fail/" + file);
+                String testFileString = new String(Files.readAllBytes(Paths.get("target/test-classes/w3c/activitystreams-master/test/" + file)));
+                LOGGER.info("Content: " + testFileString);
+                ObjectNode testFileObjectNode = MAPPER.readValue(testFileString, ObjectNode.class);
+                LOGGER.info("Object:" + testFileObjectNode);
+            }
+        }
+    }
+}


### PR DESCRIPTION
set up ability to collect, validate, and package relevant documents from w3c github
using the google download plugin for now until the documents stabilize enough to be brought into the source tree
note that two tests are @ignore because they fail currently.
we will need to spend time playing with the jackson setup to make it handle all of these example properly.