### PR TITLE
STREAMS-469: fit failing ITs in streams-provider-rss

### DIFF
--- a/streams-contrib/streams-provider-rss/pom.xml
+++ b/streams-contrib/streams-provider-rss/pom.xml
@@ -86,9 +86,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>rome</groupId>
+            <groupId>com.rometools</groupId>
             <artifactId>rome</artifactId>
-            <version>1.0</version>
+            <version>1.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssEventProcessor.java
+++ b/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssEventProcessor.java
@@ -24,7 +24,8 @@ import org.apache.streams.rss.serializer.SyndEntryActivitySerializer;
 import org.apache.streams.rss.serializer.SyndEntrySerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.syndication.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndEntry;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssStreamProviderTask.java
+++ b/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/provider/RssStreamProviderTask.java
@@ -25,10 +25,11 @@ import org.apache.streams.rss.serializer.SyndEntrySerializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.io.FeedException;
-import com.sun.syndication.io.SyndFeedInput;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.io.FeedException;
+import com.rometools.rome.io.SyndFeedInput;
+
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +78,7 @@ public class RssStreamProviderTask implements Runnable {
    * Map that contains the Set of previously seen articles by an rss feed.
    */
   @VisibleForTesting
-  protected static final Map<String, Set<String>> PREVIOUSLY_SEEN = new ConcurrentHashMap<>();
+  protected Map<String, Set<String>> PREVIOUSLY_SEEN = new ConcurrentHashMap<>();
 
 
   private BlockingQueue<StreamsDatum> dataQueue;

--- a/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/serializer/SyndEntrySerializer.java
+++ b/streams-contrib/streams-provider-rss/src/main/java/org/apache/streams/rss/serializer/SyndEntrySerializer.java
@@ -21,16 +21,15 @@ package org.apache.streams.rss.serializer;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.sun.syndication.feed.module.Module;
-import com.sun.syndication.feed.rss.Category;
-import com.sun.syndication.feed.rss.Content;
-import com.sun.syndication.feed.rss.Enclosure;
-import com.sun.syndication.feed.synd.SyndContent;
-import com.sun.syndication.feed.synd.SyndEnclosure;
-import com.sun.syndication.feed.synd.SyndEntry;
-import com.sun.syndication.feed.synd.SyndFeed;
-import com.sun.syndication.feed.synd.SyndImage;
-import com.sun.syndication.feed.synd.SyndLinkImpl;
+import com.rometools.rome.feed.module.Module;
+import com.rometools.rome.feed.rss.Enclosure;
+import com.rometools.rome.feed.synd.SyndContent;
+import com.rometools.rome.feed.synd.SyndEnclosure;
+import com.rometools.rome.feed.synd.SyndEntry;
+import com.rometools.rome.feed.synd.SyndFeed;
+import com.rometools.rome.feed.synd.SyndImage;
+import com.rometools.rome.feed.synd.SyndLinkImpl;
+
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.slf4j.Logger;
@@ -82,9 +81,9 @@ public class SyndEntrySerializer {
     }
     ArrayNode cats = factory.arrayNode();
     for (Object obj : categories) {
-      if (obj instanceof Category) {
+      if (obj instanceof com.rometools.rome.feed.rss.Category) {
         ObjectNode catNode = factory.objectNode();
-        Category category = (Category) obj;
+        com.rometools.rome.feed.rss.Category category = (com.rometools.rome.feed.rss.Category) obj;
         if (category.getDomain() != null) {
           catNode.put("domain", category.getDomain());
         }
@@ -92,8 +91,8 @@ public class SyndEntrySerializer {
           catNode.put("value", category.getValue());
         }
         cats.add(catNode);
-      } else if (obj instanceof com.sun.syndication.feed.atom.Category) {
-        com.sun.syndication.feed.atom.Category category = (com.sun.syndication.feed.atom.Category) obj;
+      } else if (obj instanceof com.rometools.rome.feed.atom.Category) {
+        com.rometools.rome.feed.atom.Category category = (com.rometools.rome.feed.atom.Category) obj;
         ObjectNode catNode = factory.objectNode();
         if (category.getLabel() != null) {
           catNode.put("label", category.getLabel());
@@ -120,13 +119,13 @@ public class SyndEntrySerializer {
     ArrayNode contentsArray = factory.arrayNode();
     for (Object obj : contents) {
       ObjectNode content = factory.objectNode();
-      if (obj instanceof Content) {
-        Content rssContent = (Content) obj;
+      if (obj instanceof com.rometools.rome.feed.rss.Content) {
+        com.rometools.rome.feed.rss.Content rssContent = (com.rometools.rome.feed.rss.Content) obj;
         content.put("type", rssContent.getType());
         content.put("value", rssContent.getValue());
       }
-      if (obj instanceof com.sun.syndication.feed.atom.Content) {
-        com.sun.syndication.feed.atom.Content atomContent = (com.sun.syndication.feed.atom.Content) obj;
+      if (obj instanceof com.rometools.rome.feed.atom.Content) {
+        com.rometools.rome.feed.atom.Content atomContent = (com.rometools.rome.feed.atom.Content) obj;
         content.put("type", atomContent.getType());
         content.put("value", atomContent.getValue());
         content.put("mode", atomContent.getMode());
@@ -248,7 +247,9 @@ public class SyndEntrySerializer {
   }
 
   private void serializeLinks(ObjectNode root, JsonNodeFactory factory, List links) {
-    if (links.get(0) instanceof String) {
+    if( links.size() == 0 ) {
+      root.put("links", factory.arrayNode());
+    } else  if (links.get(0) instanceof String) {
       serializeListOfStrings(links, "links", root, factory);
     } else if (links.get(0) instanceof SyndLinkImpl) {
       ArrayNode linksArray = factory.arrayNode();


### PR DESCRIPTION
As best I can tell, junit forking was allowing the tests to pass - they started failing under TestNG.
Wound up removing the static modifier from some state where it didn’t really make sense.
Along the way, upgraded the underlying library to one under active maintenance.